### PR TITLE
Updated RegionDialogService to support proper region Navigation

### DIFF
--- a/PrismOutlook/Core/Dialogs/RegionDialogService.cs
+++ b/PrismOutlook/Core/Dialogs/RegionDialogService.cs
@@ -9,7 +9,7 @@ using System.Windows;
 
 namespace PrismOutlook.Core.Dialogs
 {
-    public class RegionDialogService : IRegionDialogService
+   public class RegionDialogService : IRegionDialogService
     {
         private readonly IContainerExtension _containerExtension;
         private readonly IRegionManager _regionManager;
@@ -20,6 +20,9 @@ namespace PrismOutlook.Core.Dialogs
             _regionManager = regionManager;
         }
 
+
+
+
         public void Show(string name, IDialogParameters dialogParameters, Action<IDialogResult> callback)
         {
             var window = _containerExtension.Resolve<RibbonDialogWindow>();
@@ -29,57 +32,88 @@ namespace PrismOutlook.Core.Dialogs
 
             IRegion region = scopedRegionManager.Regions[RegionNames.ContentRegion];
 
-            region.RequestNavigate(name);
-
-            var activeView = region.ActiveViews.FirstOrDefault() as FrameworkElement;
-            IDialogAware dialogAware = activeView.DataContext as IDialogAware;
-            if (dialogAware == null)
-                throw new ArgumentNullException("dialogAware");
-
-            dialogAware.OnDialogOpened(dialogParameters);
-
             Action<IDialogResult> requestCloseHandler = null;
+
             requestCloseHandler = (result) =>
-            {
-                window.Result = result;
-                window.Close();
-            };
+                       {
+                           window.Result = result;
+                           window.Close();
+                       };
 
             CancelEventHandler closingHandler = null;
             closingHandler = (o, e) =>
             {
-                if (!dialogAware.CanCloseDialog())
-                    e.Cancel = true;
+                if (o is ContentControl co && co.Content is FrameworkElement fe && fe.DataContext is IDialogAware dialogAware)
+                {
+                    if (!dialogAware.CanCloseDialog())
+                        e.Cancel = true;
+                }
             };
             window.Closing += closingHandler;
+
 
             RoutedEventHandler loadedHandler = null;
             loadedHandler = (o, e) =>
             {
                 window.Loaded -= loadedHandler;
-                dialogAware.RequestClose += requestCloseHandler;
+                if (o is FrameworkElement fe && fe.DataContext is IDialogAware dialogAware)
+                {
+                    dialogAware.RequestClose += requestCloseHandler;
+                }
             };
             window.Loaded += loadedHandler;
+
 
             EventHandler closedHandler = null;
             closedHandler = (o, e) =>
             {
                 window.Closed -= closedHandler;
                 window.Closing -= closingHandler;
-                dialogAware.RequestClose -= requestCloseHandler;
 
-                dialogAware.OnDialogClosed();
+                if (o is FrameworkElement fe && fe.DataContext is IDialogAware dialogAware)
+                {
+                    dialogAware.RequestClose -= requestCloseHandler;
+                    dialogAware.OnDialogClosed();
+                }
 
                 var result = window.Result;
                 if (result == null)
                     result = new DialogResult();
 
-                callback.Invoke(result);                
+                callback?.Invoke(result);
 
                 window.DataContext = null;
                 window.Content = null;
             };
+
             window.Closed += closedHandler;
+
+            region.ActiveViews.CollectionChanged += (sender, args) =>
+              {
+                  if (args.Action == NotifyCollectionChangedAction.Add)
+                  {
+                      foreach (FrameworkElement view in args.NewItems)
+                      {
+                          IDialogAware dialogAware = view.DataContext as IDialogAware;
+                          if (dialogAware == null)
+                              throw new ArgumentNullException("dialogAware");
+
+                          dialogAware.RequestClose += requestCloseHandler;
+                      }
+                  }
+                  else if (args.Action == NotifyCollectionChangedAction.Remove)
+                  {
+                      foreach (FrameworkElement view in args.OldItems)
+                      {
+                          IDialogAware dialogAware = view.DataContext as IDialogAware;
+                          dialogAware.RequestClose -= requestCloseHandler;
+                      }
+                  }
+
+              };
+
+
+            region.RequestNavigate(name);
 
             window.Owner = Application.Current.MainWindow;
             window.WindowStartupLocation = WindowStartupLocation.CenterOwner;


### PR DESCRIPTION
As requested in your last stream this code will properly close all the navigated views with proper event clean up and memory leak.

With the help of your IRegionManagerAware and RegionManagerAwareBehavior all the views can be closed properly.