### PR TITLE
Upgrade to .NET 6 and using trial versions of Infragistics WPF Nuget packages

### DIFF
--- a/Modules/PrismOutlook.Modules.Calendar/PrismOutlook.Modules.Calendar.csproj
+++ b/Modules/PrismOutlook.Modules.Calendar/PrismOutlook.Modules.Calendar.csproj
@@ -13,9 +13,6 @@
     <PackageReference Include="Infragistics.WPF.DataTree.Trial" Version="22.1.71" />
     <PackageReference Include="Infragistics.WPF.OutlookBar.Trial" Version="22.1.71" />
     <PackageReference Include="Infragistics.WPF.Ribbon.Trial" Version="22.1.71" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageReference Include="Microsoft.Windows.Compatibility" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Prism.Wpf" Version="7.2.0.1367" />

--- a/Modules/PrismOutlook.Modules.Calendar/PrismOutlook.Modules.Calendar.csproj
+++ b/Modules/PrismOutlook.Modules.Calendar/PrismOutlook.Modules.Calendar.csproj
@@ -1,100 +1,23 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{A3F15124-467E-44CD-9C2C-5B83AA0A8306}</ProjectGuid>
-    <OutputType>library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>PrismOutlook.Modules.Calendar</RootNamespace>
-    <AssemblyName>PrismOutlook.Modules.Calendar</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <WarningLevel>4</WarningLevel>
-    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <OutputType>Library</OutputType>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <UseWPF>true</UseWPF>
+    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xaml">
-      <RequiredTargetFramework>4.0</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="WindowsBase" />
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="CalendarModule.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Properties\Resources.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>Resources.resx</DependentUpon>
-    </Compile>
-    <Compile Include="Properties\Settings.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Settings.settings</DependentUpon>
-      <DesignTimeSharedInput>True</DesignTimeSharedInput>
-    </Compile>
-    <Compile Include="ViewModels\ViewAViewModel.cs" />
-    <Compile Include="Views\ViewA.xaml.cs">
-      <DependentUpon>ViewA.xaml</DependentUpon>
-    </Compile>
-    <EmbeddedResource Include="Properties\Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-    <None Include="Properties\Settings.settings">
-      <Generator>SettingsSingleFileGenerator</Generator>
-      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
-    </None>
     <AppDesigner Include="Properties\" />
   </ItemGroup>
-  <ItemGroup />
   <ItemGroup>
-    <Page Include="Views\ViewA.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
+    <PackageReference Include="Infragistics.WPF.DataTree.Trial" Version="22.1.71" />
+    <PackageReference Include="Infragistics.WPF.OutlookBar.Trial" Version="22.1.71" />
+    <PackageReference Include="Infragistics.WPF.Ribbon.Trial" Version="22.1.71" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
+    <PackageReference Include="Microsoft.Windows.Compatibility" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Infragistics.WPF.DataTree">
-      <Version>19.1.84</Version>
-    </PackageReference>
-    <PackageReference Include="Infragistics.WPF.OutlookBar">
-      <Version>19.1.84</Version>
-    </PackageReference>
-    <PackageReference Include="Infragistics.WPF.Ribbon">
-      <Version>19.1.84</Version>
-    </PackageReference>
     <PackageReference Include="Prism.Wpf" Version="7.2.0.1367" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Modules/PrismOutlook.Modules.Contacts/PrismOutlook.Modules.Contacts.csproj
+++ b/Modules/PrismOutlook.Modules.Contacts/PrismOutlook.Modules.Contacts.csproj
@@ -1,119 +1,20 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{150D400D-05EB-487C-88A6-3EB246A09DE7}</ProjectGuid>
-    <OutputType>library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>PrismOutlook.Modules.Contacts</RootNamespace>
-    <AssemblyName>PrismOutlook.Modules.Contacts</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <WarningLevel>4</WarningLevel>
-    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <OutputType>Library</OutputType>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <UseWPF>true</UseWPF>
+    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xaml">
-      <RequiredTargetFramework>4.0</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="WindowsBase" />
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="ContactsModule.cs" />
-    <Compile Include="Menus\ContactsGroup.xaml.cs">
-      <DependentUpon>ContactsGroup.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="Menus\HomeTab.xaml.cs">
-      <DependentUpon>HomeTab.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="Properties\AssemblyInfo.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Properties\Resources.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>Resources.resx</DependentUpon>
-    </Compile>
-    <Compile Include="Properties\Settings.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Settings.settings</DependentUpon>
-      <DesignTimeSharedInput>True</DesignTimeSharedInput>
-    </Compile>
-    <Compile Include="ViewModels\ViewAViewModel.cs" />
-    <Compile Include="Views\ViewA.xaml.cs">
-      <DependentUpon>ViewA.xaml</DependentUpon>
-    </Compile>
-    <EmbeddedResource Include="Properties\Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-    <None Include="Properties\Settings.settings">
-      <Generator>SettingsSingleFileGenerator</Generator>
-      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
-    </None>
     <AppDesigner Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\PrismOutlook.Core\PrismOutlook.Core.csproj">
-      <Project>{0CBBB120-D481-42BA-98EC-E5BA133C79A7}</Project>
-      <Name>PrismOutlook.Core</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\..\PrismOutlook.Core\PrismOutlook.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Page Include="Menus\ContactsGroup.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="Menus\HomeTab.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="Views\ViewA.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
+    <PackageReference Include="Infragistics.WPF.DataTree.Trial" Version="22.1.71" />
+    <PackageReference Include="Infragistics.WPF.OutlookBar.Trial" Version="22.1.71" />
+    <PackageReference Include="Infragistics.WPF.Ribbon.Trial" Version="22.1.71" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Infragistics.WPF.DataTree">
-      <Version>19.1.84</Version>
-    </PackageReference>
-    <PackageReference Include="Infragistics.WPF.OutlookBar">
-      <Version>19.1.84</Version>
-    </PackageReference>
-    <PackageReference Include="Infragistics.WPF.Ribbon">
-      <Version>19.1.84</Version>
-    </PackageReference>
-    <PackageReference Include="Prism.Wpf" Version="7.2.0.1367" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Modules/PrismOutlook.Modules.Mail/PrismOutlook.Modules.Mail.csproj
+++ b/Modules/PrismOutlook.Modules.Mail/PrismOutlook.Modules.Mail.csproj
@@ -1,183 +1,28 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{0EA057BF-FDFE-4F68-AD8F-D4A58C76D27C}</ProjectGuid>
-    <OutputType>library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>PrismOutlook.Modules.Mail</RootNamespace>
-    <AssemblyName>PrismOutlook.Modules.Mail</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <WarningLevel>4</WarningLevel>
-    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <OutputType>Library</OutputType>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <UseWPF>true</UseWPF>
+    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xaml">
-      <RequiredTargetFramework>4.0</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="WindowsBase" />
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Controls\MessageDisplayControl.xaml.cs">
-      <DependentUpon>MessageDisplayControl.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="Converters\MailAddressConverter.cs" />
-    <Compile Include="MailModule.cs" />
-    <Compile Include="MailParameters.cs" />
-    <Compile Include="Menus\HomeTab.xaml.cs">
-      <DependentUpon>HomeTab.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="Menus\MailGroup.xaml.cs">
-      <DependentUpon>MailGroup.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="Menus\MessageReadOnlyTab.xaml.cs">
-      <DependentUpon>MessageReadOnlyTab.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="Menus\MessageTab.xaml.cs">
-      <DependentUpon>MessageTab.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="MessageModes.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Properties\Resources.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>Resources.resx</DependentUpon>
-    </Compile>
-    <Compile Include="Properties\Settings.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Settings.settings</DependentUpon>
-      <DesignTimeSharedInput>True</DesignTimeSharedInput>
-    </Compile>
-    <Compile Include="FolderParameters.cs" />
-    <Compile Include="ViewModels\MailGroupViewModel.cs" />
-    <Compile Include="ViewModels\MailListViewModel.cs" />
-    <Compile Include="ViewModels\MessageReadOnlyViewModel.cs" />
-    <Compile Include="ViewModels\MessageViewModel.cs" />
-    <Compile Include="ViewModels\MessageViewModelBase.cs" />
-    <Compile Include="Views\MailList.xaml.cs">
-      <DependentUpon>MailList.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="Views\MessageReadOnlyView.xaml.cs">
-      <DependentUpon>MessageReadOnlyView.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="Views\MessageView.xaml.cs">
-      <DependentUpon>MessageView.xaml</DependentUpon>
-    </Compile>
-    <EmbeddedResource Include="Properties\Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-    <None Include="Properties\Settings.settings">
-      <Generator>SettingsSingleFileGenerator</Generator>
-      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
-    </None>
     <AppDesigner Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\PrismOutlook.Business\PrismOutlook.Business.csproj">
-      <Project>{4D17ACBA-3B6B-4E68-9DE1-92E91EFF7A27}</Project>
-      <Name>PrismOutlook.Business</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\PrismOutlook.Core\PrismOutlook.Core.csproj">
-      <Project>{0cbbb120-d481-42ba-98ec-e5ba133c79a7}</Project>
-      <Name>PrismOutlook.Core</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\PrismOutlook.Services.Interfaces\PrismOutlook.Services.Interfaces.csproj">
-      <Project>{ab96663e-e7b4-45db-a386-ca73f1552794}</Project>
-      <Name>PrismOutlook.Services.Interfaces</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\PrismOutlook.Services\PrismOutlook.Services.csproj">
-      <Project>{1943786f-b068-4bd4-8ad3-5ceaad475e30}</Project>
-      <Name>PrismOutlook.Services</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\..\PrismOutlook.Business\PrismOutlook.Business.csproj" />
+    <ProjectReference Include="..\..\PrismOutlook.Core\PrismOutlook.Core.csproj" />
+    <ProjectReference Include="..\..\PrismOutlook.Services.Interfaces\PrismOutlook.Services.Interfaces.csproj" />
+    <ProjectReference Include="..\..\PrismOutlook.Services\PrismOutlook.Services.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Page Include="Controls\MessageDisplayControl.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="Menus\HomeTab.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="Menus\MailGroup.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="Menus\MessageReadOnlyTab.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="Menus\MessageTab.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="Views\MailList.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="Views\MessageReadOnlyView.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="Views\MessageView.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Infragistics.WPF.DataGrids">
-      <Version>19.1.84</Version>
-    </PackageReference>
-    <PackageReference Include="Infragistics.WPF.DataTree">
-      <Version>19.1.84</Version>
-    </PackageReference>
-    <PackageReference Include="Infragistics.WPF.OutlookBar">
-      <Version>19.1.84</Version>
-    </PackageReference>
-    <PackageReference Include="Infragistics.WPF.Ribbon">
-      <Version>19.1.84</Version>
-    </PackageReference>
-    <PackageReference Include="Infragistics.WPF.RichTextDocument.Rtf">
-      <Version>19.1.84</Version>
-    </PackageReference>
-    <PackageReference Include="Infragistics.WPF.RichTextEditor">
-      <Version>19.1.84</Version>
-    </PackageReference>
-    <PackageReference Include="Prism.Wpf" Version="7.2.0.1367" />
+    <PackageReference Include="Infragistics.WPF.DataGrids.Trial" Version="22.1.71" />
+    <PackageReference Include="Infragistics.WPF.DataTree.Trial" Version="22.1.71" />
+    <PackageReference Include="Infragistics.WPF.OutlookBar.Trial" Version="22.1.71" />
+    <PackageReference Include="Infragistics.WPF.Ribbon.Trial" Version="22.1.71" />
+    <PackageReference Include="Infragistics.WPF.RichTextDocument.Rtf.Trial" Version="22.1.71" />
+    <PackageReference Include="Infragistics.WPF.RichTextDocument.Trial" Version="22.1.71" />
+    <PackageReference Include="Infragistics.WPF.RichTextEditor.Trial" Version="22.1.71" />
   </ItemGroup>
   <ItemGroup>
     <Resource Include="Images\Bold16.png" />
@@ -210,5 +55,4 @@
     <Resource Include="Images\ReplyAll16.png" />
     <Resource Include="Images\ReplyAll32.png" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/PrismOutlook.Core/PrismOutlook.Core.csproj
+++ b/PrismOutlook.Core/PrismOutlook.Core.csproj
@@ -1,114 +1,19 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{0CBBB120-D481-42BA-98EC-E5BA133C79A7}</ProjectGuid>
-    <OutputType>library</OutputType>
-    <RootNamespace>PrismOutlook.Core</RootNamespace>
-    <AssemblyName>PrismOutlook.Core</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <WarningLevel>4</WarningLevel>
-    <Deterministic>true</Deterministic>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <OutputType>Library</OutputType>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <UseWPF>true</UseWPF>
+    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CommonServiceLocator, Version=2.0.4.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">
-      <HintPath>..\packages\CommonServiceLocator.2.0.4\lib\net47\CommonServiceLocator.dll</HintPath>
-    </Reference>
-    <Reference Include="InfragisticsWPF, Version=19.1.20191.84, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL">
-      <HintPath>..\packages\Infragistics.WPF.19.1.84\lib\net40\InfragisticsWPF.dll</HintPath>
-    </Reference>
-    <Reference Include="InfragisticsWPF.Controls.Editors.XamRichTextEditor, Version=19.1.20191.84, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL">
-      <HintPath>..\packages\Infragistics.WPF.RichTextEditor.19.1.84\lib\net40\InfragisticsWPF.Controls.Editors.XamRichTextEditor.dll</HintPath>
-    </Reference>
-    <Reference Include="InfragisticsWPF.Controls.Menus.XamMenu, Version=19.1.20191.84, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL">
-      <HintPath>..\packages\Infragistics.WPF.Menus.19.1.84\lib\net40\InfragisticsWPF.Controls.Menus.XamMenu.dll</HintPath>
-    </Reference>
-    <Reference Include="InfragisticsWPF.Documents.RichTextDocument, Version=19.1.20191.84, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL">
-      <HintPath>..\packages\Infragistics.WPF.RichTextDocument.19.1.84\lib\net40\InfragisticsWPF.Documents.RichTextDocument.dll</HintPath>
-    </Reference>
-    <Reference Include="InfragisticsWPF.Undo, Version=19.1.20191.84, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL">
-      <HintPath>..\packages\Infragistics.WPF.Undo.19.1.84\lib\net40\InfragisticsWPF.Undo.dll</HintPath>
-    </Reference>
-    <Reference Include="Prism, Version=7.2.0.1367, Culture=neutral, PublicKeyToken=40ee6c3a2184dc59, processorArchitecture=MSIL">
-      <HintPath>..\packages\Prism.Core.7.2.0.1367\lib\net45\Prism.dll</HintPath>
-    </Reference>
-    <Reference Include="Prism.Wpf, Version=7.2.0.1367, Culture=neutral, PublicKeyToken=40ee6c3a2184dc59, processorArchitecture=MSIL">
-      <HintPath>..\packages\Prism.Wpf.7.2.0.1367\lib\net45\Prism.Wpf.dll</HintPath>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Prism.Wpf.7.2.0.1367\lib\net45\System.Windows.Interactivity.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Xml" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xaml">
-      <RequiredTargetFramework>4.0</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="WindowsBase" />
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
+    <PackageReference Include="Infragistics.WPF.RichTextDocument.Trial" Version="22.1.71" />
+    <PackageReference Include="Infragistics.WPF.RichTextEditor.Trial" Version="22.1.71" />
+    <PackageReference Include="Infragistics.WPF.Trial" Version="22.1.71" />
+    <PackageReference Include="Infragistics.WPF.Undo.Trial" Version="22.1.71" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="Prism.Wpf" Version="7.2.0.1367" />
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
+    <PackageReference Include="Microsoft.Windows.Compatibility" Version="6.0.0" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="ApplicationCommands.cs" />
-    <Compile Include="IRegionDialogService.cs" />
-    <Compile Include="IOutlookBarGroup.cs" />
-    <Compile Include="ISupportDataContext.cs" />
-    <Compile Include="ISupportRichText.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Properties\Resources.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>Resources.resx</DependentUpon>
-    </Compile>
-    <Compile Include="Properties\Settings.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Settings.settings</DependentUpon>
-      <DesignTimeSharedInput>True</DesignTimeSharedInput>
-    </Compile>
-    <Compile Include="RegionNames.cs" />
-    <Compile Include="DependentViewAttribute.cs" />
-    <Compile Include="ViewModelBase.cs" />
-    <EmbeddedResource Include="Properties\Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-    <None Include="packages.config" />
-    <None Include="Properties\Settings.settings">
-      <Generator>SettingsSingleFileGenerator</Generator>
-      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
-    </None>
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/PrismOutlook.Core/PrismOutlook.Core.csproj
+++ b/PrismOutlook.Core/PrismOutlook.Core.csproj
@@ -11,9 +11,6 @@
     <PackageReference Include="Infragistics.WPF.RichTextEditor.Trial" Version="22.1.71" />
     <PackageReference Include="Infragistics.WPF.Trial" Version="22.1.71" />
     <PackageReference Include="Infragistics.WPF.Undo.Trial" Version="22.1.71" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Prism.Wpf" Version="7.2.0.1367" />
-    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageReference Include="Microsoft.Windows.Compatibility" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/PrismOutlook/PrismOutlook.csproj
+++ b/PrismOutlook/PrismOutlook.csproj
@@ -1,146 +1,23 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{F4D2DFA9-8237-4554-A57D-334E835B5277}</ProjectGuid>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <OutputType>WinExe</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>PrismOutlook</RootNamespace>
-    <AssemblyName>PrismOutlook</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <WarningLevel>4</WarningLevel>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <UseWPF>true</UseWPF>
+    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xaml">
-      <RequiredTargetFramework>4.0</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="WindowsBase" />
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-  </ItemGroup>
-  <ItemGroup>
-    <ApplicationDefinition Include="App.xaml">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-    </ApplicationDefinition>
-    <Page Include="Core\Dialogs\RibbonDialogWindow.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="Views\MainWindow.xaml">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-    </Page>
-    <Compile Include="App.xaml.cs">
-      <DependentUpon>App.xaml</DependentUpon>
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Core\Dialogs\DialogServiceBase.cs" />
-    <Compile Include="Core\Dialogs\RegionDialogService.cs" />
-    <Compile Include="Core\Dialogs\RibbonDialogWindow.xaml.cs">
-      <DependentUpon>RibbonDialogWindow.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="Core\Regions\DependentViewInfo.cs" />
-    <Compile Include="Core\Regions\DependentViewRegionBehavior.cs" />
-    <Compile Include="Core\Regions\XamOutlookBarRegionAdapter.cs" />
-    <Compile Include="Core\Regions\XamRibbonRegionAdapter.cs" />
-    <Compile Include="ViewModels\MainWindowViewModel.cs" />
-    <Compile Include="Views\MainWindow.xaml.cs">
-      <DependentUpon>MainWindow.xaml</DependentUpon>
-      <SubType>Code</SubType>
-    </Compile>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Properties\AssemblyInfo.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Properties\Resources.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>Resources.resx</DependentUpon>
-    </Compile>
-    <Compile Include="Properties\Settings.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Settings.settings</DependentUpon>
-      <DesignTimeSharedInput>True</DesignTimeSharedInput>
-    </Compile>
-    <EmbeddedResource Include="Properties\Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-    <None Include="Properties\Settings.settings">
-      <Generator>SettingsSingleFileGenerator</Generator>
-      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Infragistics.WPF.DataGrids">
-      <Version>19.1.84</Version>
-    </PackageReference>
-    <PackageReference Include="Infragistics.WPF.DataTree">
-      <Version>19.1.84</Version>
-    </PackageReference>
-    <PackageReference Include="Infragistics.WPF.OutlookBar">
-      <Version>19.1.84</Version>
-    </PackageReference>
-    <PackageReference Include="Infragistics.WPF.Ribbon">
-      <Version>19.1.84</Version>
-    </PackageReference>
-    <PackageReference Include="Infragistics.WPF.Themes.Office2013">
-      <Version>19.1.84</Version>
-    </PackageReference>
+    <PackageReference Include="Infragistics.WPF.Themes.Office2013.Trial" Version="22.1.71" />
     <PackageReference Include="Prism.Unity" Version="7.2.0.1367" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Modules\PrismOutlook.Modules.Contacts\PrismOutlook.Modules.Contacts.csproj">
-      <Project>{150D400D-05EB-487C-88A6-3EB246A09DE7}</Project>
-      <Name>PrismOutlook.Modules.Contacts</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Modules\PrismOutlook.Modules.Mail\PrismOutlook.Modules.Mail.csproj">
-      <Project>{0EA057BF-FDFE-4F68-AD8F-D4A58C76D27C}</Project>
-      <Name>PrismOutlook.Modules.Mail</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\PrismOutlook.Core\PrismOutlook.Core.csproj">
-      <Project>{0cbbb120-d481-42ba-98ec-e5ba133c79a7}</Project>
-      <Name>PrismOutlook.Core</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\PrismOutlook.Services.Interfaces\PrismOutlook.Services.Interfaces.csproj">
-      <Project>{ab96663e-e7b4-45db-a386-ca73f1552794}</Project>
-      <Name>PrismOutlook.Services.Interfaces</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\Modules\PrismOutlook.Modules.Contacts\PrismOutlook.Modules.Contacts.csproj" />
+    <ProjectReference Include="..\Modules\PrismOutlook.Modules.Mail\PrismOutlook.Modules.Mail.csproj" />
+    <ProjectReference Include="..\PrismOutlook.Core\PrismOutlook.Core.csproj" />
+    <ProjectReference Include="..\PrismOutlook.Services.Interfaces\PrismOutlook.Services.Interfaces.csproj" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <ItemGroup>
+    <Compile Remove="Core\Dialogs\RibbonWindow.xaml.cs" />
+    <Page Remove="Core\Dialogs\RibbonWindow.xaml" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
I started learning through your YouTube video series on building the PrismOutlook application (thank you very much for the same). For me, it was convenient to use .NET 6, and also the versions of Infragistics Nuget packages there were paid versions which I did not have access to, so I used the trial versions. I am not sure if this may be of any use to others. In that case, please feel free to drop this PR.